### PR TITLE
Adding bash as command interpreter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.7
+
+Added bash as command interpreter of local-exec.
+
 ## 0.0.6
 
 Added escaping of local-exec command path to handle Windows paths.

--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,7 @@ resource "null_resource" "docker_pullpush" {
     shell_hash = sha256("${var.docker_source}${var.ecr_repo_name}${var.ecr_repo_tag}")
   }
   provisioner "local-exec" {
+    interpreter = ["bash", "-c"]
     command = "${local.module_path}/docker_pullpush.sh ${var.docker_source} ${var.aws_region} ${var.aws_account_id} ${var.ecr_repo_name} ${var.ecr_repo_tag} ${var.aws_profile}"
   }
 }


### PR DESCRIPTION
Hi!

In the first place, I want to thank you for publishing this repo.

I had this error on windows using Git Bash and PowerShell (I replaced the params):
`Error running command '.terraform/modules/ecr_mirror/docker_pullpush.sh image zone id tag profile': exit status 1. Output: ".terraform" is not recognized as an internal command`

This change worked for me but I haven't tested it on Linux.

Regards,
Javier.