### PR TITLE
Use env bash to make script more portable

### DIFF
--- a/docker_pullpush.sh
+++ b/docker_pullpush.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ ${#6} -gt 0 ]]; then
     profile="--profile $6"


### PR DESCRIPTION
Some systems might not have the `/bin/bash` link, they might just have a `/bin/sh` that detects whether to run `sh` or `bash` automatically. One example of this is NixOS, or the BSDs.

Instead you can rely on the `env` utility to figure out where `bash` is, using the user's `PATH`. `env` will look into all the available paths and use the first path that matches the binary you're looking for, which should make this script more portable.